### PR TITLE
修复访问用户主页后账户状态错误的问题

### DIFF
--- a/FrontEnd/src/store/modules/users.js
+++ b/FrontEnd/src/store/modules/users.js
@@ -51,9 +51,7 @@ const mutations = {
    * @param {Object} payload 需要更新的用户信息
    */
   updateUserInfo(state, payload) {
-    state.data = assign({}, state.data, {
-      [payload.id]: payload,
-    })
+    state.data[payload.id] = assign({}, state.data[payload.id], payload)
   },
 }
 


### PR DESCRIPTION
由于不同接口的权限问题，导致译者访问自己的主页后，身份会变为未认证用户。

